### PR TITLE
Add tabix indexing before bcftools region query, fix SnpEff database …

### DIFF
--- a/_episodes/resequencing_tutorial.md
+++ b/_episodes/resequencing_tutorial.md
@@ -627,6 +627,9 @@ bcftools stats cohort.snps.filtered.vcf.gz | grep "^SN"
 # Keep only PASS variants
 bcftools view -f PASS -O z -o cohort.snps.pass.vcf.gz cohort.snps.filtered.vcf.gz
 
+# Index the filtered VCF (required for region queries)
+tabix -p vcf cohort.snps.pass.vcf.gz
+
 # Extract specific genomic region
 # Note: Ensembl TAIR10 uses "1", "2", ... (not "Chr1", "Chr2")
 bcftools view cohort.snps.pass.vcf.gz 1:100000-200000
@@ -648,16 +651,16 @@ SnpEff predicts the functional effect of each variant (missense, nonsense, synon
 # List available databases
 snpEff databases | grep -i arabidopsis
 
-# Download database (example: Arabidopsis TAIR10)
-# Note: the exact database name may vary by SnpEff version.
-# Use the output of the command above to find the correct name.
-snpEff download athalianaTair10
+# Download database
+# For SnpEff 5.x, the database name is "Arabidopsis_thaliana"
+# Use the output of the command above to confirm the exact name.
+snpEff download Arabidopsis_thaliana
 ```
 
 ### Annotate Variants
 
 ```bash
-snpEff -v athalianaTair10 cohort.snps.pass.vcf.gz > cohort.snps.annotated.vcf
+snpEff Arabidopsis_thaliana cohort.snps.pass.vcf.gz > cohort.snps.annotated.vcf
 
 # snpEff also generates snpEff_summary.html and snpEff_genes.txt
 ```


### PR DESCRIPTION
…name

- Add `tabix -p vcf` step before `bcftools view` region query (fails without index)
- Change SnpEff database name from `athalianaTair10` to `Arabidopsis_thaliana` (verified: `athalianaTair10` does not exist in SnpEff 5.x)

Please delete the text below before submitting your contribution. 

---

Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.  

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact Kate Hertweck (k8hertweck@gmail.com).  

---
